### PR TITLE
updated sit for light and dark modes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,11 +18,11 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={inter.className}>
-      <body className="bg-zinc-800 min-h-screen">
+      <body className="bg-zinc-200 dark:bg-zinc-800 min-h-screen">
         <div className="container max-w-7xl mx-auto">
           <Navbar />
         </div>
-        <div className="container max-w-7xl mx-auto text-gray-400">
+        <div className="container max-w-7xl mx-auto text-gray-700 dark:text-gray-400">
           {children}
         </div>
         <div className="sticky top-[100vh] m-2">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,9 +5,9 @@ import NSPLogo from "./UI/NSPLogo";
 
 const Footer = () => {
   return (
-    <footer className="bg-zinc-800 w-full max-w-screen-xl mx-auto">
-      <hr className="mx-auto border-gray-700" />
-      <div className="flex items-center justify-between font-medium text-gray-400 p-5">
+    <footer className="w-full max-w-screen-xl mx-auto">
+      <hr className="mx-auto border-gray-400 dark:border-gray-700" />
+      <div className="flex items-center justify-between font-medium text-gray-600 dark:text-gray-400 p-5">
         <ul className="flex flex-wrap justify-between gap-3 items-center">
           <li>
             <SnoqualmiePassLogo />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,14 +9,14 @@ const Navbar = () => {
 
   return (
     <>
-      <div className="fixed top-0 inset-x-0 bg-zinc-800 py-2">
+      <div className="fixed top-0 inset-x-0 bg-zinc-200 dark:bg-zinc-800 py-2">
         <div className="flex justify-center py-2">
-          <div className="flex gap-4 md:gap-9 text-md font-semibold text-gray-400">
+          <div className="flex gap-4 md:gap-9 text-md font-semibold text-gray-600 dark:text-gray-400">
             {mainNavBar.map((link) => {
               const isActive = pathname === link.href;
               return (
                 <Link
-                  className={isActive ? "text-white" : ""}
+                  className={isActive ? "text-black dark:text-white" : ""}
                   href={link.href}
                   key={link.href}
                 >


### PR DESCRIPTION
-Updated site to have a light and dark mode

Light:
![image](https://github.com/psan2/spvsp-next/assets/69177982/48c3814c-f18a-4fa8-8f27-bf442d5ef3ca)

Dark:
![image](https://github.com/psan2/spvsp-next/assets/69177982/2d7a8591-6862-4485-8107-8b0158725054)
